### PR TITLE
Take misp_verifycert parameter into account for the delete request

### DIFF
--- a/misp-purgeevents.py
+++ b/misp-purgeevents.py
@@ -165,7 +165,7 @@ def delete_misp_events(misp, event_db):
         app_json = json.dumps(bulk)
         url = misp_url + '/events/delete'
         try:
-            x = requests.post(url, data=app_json, headers={"Content-Type":"application/json", "Accept":"application/json", "Authorization": misp_key }, timeout=60)
+            x = requests.post(url, data=app_json, headers={"Content-Type":"application/json", "Accept":"application/json", "Authorization": misp_key }, timeout=60, verify=misp_verifycert)
             cntSuccess = len(event_db)
         except:
             cntFailed = len(event_db)


### PR DESCRIPTION
At the moment, events deletions will not be effective because requests raises an exception SSLCertVerificationError if MISP certificate is auto-signed.
Addition of the argument verify in the POST request using the value of misp_verifycert parameter defined in config.py so that user can set the tool up to skip the SSL/TLS certificate check.